### PR TITLE
Pin scikit-learn version to 0.19.2 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     scripts=['bin/EukRep'],
     install_requires=[
           'numpy',
-          'scikit-learn',
+          'scikit-learn == 0.19.2',
           'kpal',
           'biopython'
     ],


### PR DESCRIPTION
This fixes #14, in which mismatched versions of scikit-learn could cause errors/warnings when loading models using pickle.

It looks like [the bioconda recipe](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/eukrep/meta.yaml) for EukRep already pins the scikit-learn version to 0.19.2, which addresses this problem for conda EukRep users. This PR pins the version in the setup.py file as well, which should address this problem for pip EukRep users.